### PR TITLE
Fix: #paragraphs grabs paragraphs in tables

### DIFF
--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -51,7 +51,7 @@ module Docx
     end
 
     def paragraphs
-      @doc.xpath('//w:document//w:body//w:p').map { |p_node| parse_paragraph_from p_node }
+      @doc.xpath('//w:document//w:body/w:p').map { |p_node| parse_paragraph_from p_node }
     end
 
     def bookmarks

--- a/spec/docx/document_spec.rb
+++ b/spec/docx/document_spec.rb
@@ -89,6 +89,12 @@ describe Docx::Document do
     it "should read embedded links" do
       expect(@doc.tables[0].columns[1].cells[1].text).to match(/^Directive/)
     end
+
+    describe '#paragraphs' do
+      it 'should not grabs paragraphs in the tables' do
+        expect(@doc.paragraphs.map(&:text)).to_not include("Second table")
+      end
+    end
   end
 
   describe 'editing'  do


### PR DESCRIPTION
With the current version of the gem, `Docx::Document#paragraphs` grabs paragraphs in tables.  
I expected the method `paragraphs` grabs paragraphs in the doc not in tables as `Docx::Document` provides `#tables` method for us to grabs paragraphs in tables. 

This pull-request provides a change on xpath used in the method to grabs all paragraphs in a doc except for ones in tables.

