### PR TITLE
Update supported ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,18 @@ language: ruby
 dist: trusty
 sudo: false
 rvm:
-- 2.4
-- 2.5
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
+  - ruby-head
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+
+cache: bundler
 bundler_args: --jobs=2
+
 script:
-- bundle exec rake spec
+  - bundle exec rake spec

--- a/docx.gemspec
+++ b/docx.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.email       = ['chrahunt@gmail.com']
   s.homepage    = 'https://github.com/chrahunt/docx'
   s.files       = Dir["README.md", "LICENSE.md", "lib/**/*.rb"]
+  s.required_ruby_version = '>= 2.4.6'
 
   s.add_dependency 'nokogiri', '~> 1.8', '>= 1.8.1'
   s.add_dependency 'rubyzip',  '~> 2.0'

--- a/docx.gemspec
+++ b/docx.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email       = ['chrahunt@gmail.com']
   s.homepage    = 'https://github.com/chrahunt/docx'
   s.files       = Dir["README.md", "LICENSE.md", "lib/**/*.rb"]
-  s.required_ruby_version = '>= 2.4.6'
+  s.required_ruby_version = '>= 2.4.0'
 
   s.add_dependency 'nokogiri', '~> 1.8', '>= 1.8.1'
   s.add_dependency 'rubyzip',  '~> 2.0'
@@ -19,3 +19,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'rake', '~> 13.0'
 end
+


### PR DESCRIPTION
ruby 2.7.0 has been released last week 🎉  
This project has not specified supported ruby versions. 

This PR provides changes on `.travis.yml` and the gemspec file to specify this gem supports 2.4.x or newer and drops 2.3(its EOR has come). 