### PR TITLE
Drop ruby 2.4 from supporeted versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 dist: trusty
 sudo: false
 rvm:
-  - 2.4
   - 2.5
   - 2.6
   - 2.7

--- a/docx.gemspec
+++ b/docx.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email       = ['chrahunt@gmail.com']
   s.homepage    = 'https://github.com/chrahunt/docx'
   s.files       = Dir['README.md', 'LICENSE.md', 'lib/**/*.rb']
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.add_dependency 'nokogiri', '~> 1.10', '>= 1.10.4'
   s.add_dependency 'rubyzip',  '~> 2.0'


### PR DESCRIPTION
Support of Ruby 2.4 has already ended in this March. 
https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

