### PR TITLE
Add ruby 3.0 to versions for testing on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
-dist: trusty
-sudo: false
+dist: xenial
 rvm:
   - 2.5
   - 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
   - ruby-head
 
 matrix:


### PR DESCRIPTION
Ruby 3.0 has been released the last month. 