### PR TITLE
Add test coverage for version 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7, "3.0", 3.1]
+        ruby: [2.6, 2.7, "3.0", 3.1, 3.2]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
With this PR, test coverage is added for Ruby 3.0, 3.1, and 3.2.