### PR TITLE
File Not Supported Error fix

### DIFF
--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -37,8 +37,10 @@ module Docx
       @doc = Nokogiri::XML(@document_xml)
       load_styles
       yield(self) if block_given?
+    rescue Zip::Error => e
+      raise 'File not supported'
     ensure
-      @zip.close
+      @zip.close unless @zip.nil?
     end
 
     # This stores the current global document properties, for now

--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -25,6 +25,7 @@ module Docx
 
       # if path-or_io is string && does not contain a null byte
       if (path_or_io.instance_of?(String) && !/\u0000/.match?(path_or_io))
+        raise Errno::EIO.new('invalid file format') if !File.extname(path_or_io).eql?('.docx')
         @zip = Zip::File.open(path_or_io)
       else
         @zip = Zip::File.open_buffer(path_or_io)
@@ -37,8 +38,6 @@ module Docx
       @doc = Nokogiri::XML(@document_xml)
       load_styles
       yield(self) if block_given?
-    rescue Zip::Error => e
-      raise 'File not supported'
     ensure
       @zip.close unless @zip.nil?
     end

--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -25,7 +25,7 @@ module Docx
 
       # if path-or_io is string && does not contain a null byte
       if (path_or_io.instance_of?(String) && !/\u0000/.match?(path_or_io))
-        raise Errno::EIO.new('invalid file format') if !File.extname(path_or_io).eql?('.docx')
+        raise Errno::EIO.new('Invalid file format') if !File.extname(path_or_io).eql?('.docx')
         @zip = Zip::File.open(path_or_io)
       else
         @zip = Zip::File.open_buffer(path_or_io)

--- a/spec/docx/document_spec.rb
+++ b/spec/docx/document_spec.rb
@@ -18,6 +18,21 @@ describe Docx::Document do
         end.to_not raise_error
       end
     end
+
+    context 'When reading a un-supported file' do
+      it 'should throw file not supported error' do
+        expect do
+          Docx::Document.open(@fixtures_path + '/invalid_format.pdf')
+        end.to raise_error(Errno::EIO, 'Input/output error - Invalid file format')
+      end
+
+      it 'should throw file not found error' do
+        expect do
+          invalid_path = @fixtures_path + '/invalid_file_path.docx'
+          Docx::Document.open(invalid_path)
+        end.to raise_error(Zip::Error, "File #{invalid_path} not found")
+      end
+    end
   end
 
   describe 'reading' do

--- a/spec/docx/document_spec.rb
+++ b/spec/docx/document_spec.rb
@@ -27,8 +27,8 @@ describe Docx::Document do
       end
 
       it 'should throw file not found error' do
+        invalid_path = @fixtures_path + '/invalid_file_path.docx'
         expect do
-          invalid_path = @fixtures_path + '/invalid_file_path.docx'
           Docx::Document.open(invalid_path)
         end.to raise_error(Zip::Error, "File #{invalid_path} not found")
       end


### PR DESCRIPTION
Hi, here I have handled the exception when an unsupported file is opened. 
For Example:
Before fix: 
 Docx::Document.open('PassPortCrop.jpeg') --> #<Zip::Error: Zip end of central directory signature not found>
After fix:
  Docx::Document.open('PassPortCrop.jpeg') --> Invalid file format
