### PR TITLE
Add ability to extract headers and footers

### DIFF
--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -75,6 +75,20 @@ module Docx
       bkmrks_hsh
     end
 
+    def headers
+      @zip.glob('word/header*.xml').map do |entry|
+        header_xml = entry.get_input_stream.read
+        Nokogiri::XML(header_xml)
+      end
+    end
+
+    def footers
+      @zip.glob('word/footer*.xml').map do |entry|
+        footer_xml = entry.get_input_stream.read
+        Nokogiri::XML(footer_xml)
+      end
+    end
+
     def to_xml
       Nokogiri::XML(@document_xml)
     end


### PR DESCRIPTION
This pull request introduces the ability to fetch and parse headers/footers.
New methods, `fetch_headers` and `fetch_footers`, to the docx gem. These methods allow users to extract and read the header and footer content from DOCX files using Nokogiri for XML parsing.

### **Changes Made:**
Added `fetch_headers` method:

```ruby
def fetch_headers
    @zip.glob('word/header*.xml').map do |entry|
      header_xml = entry.get_input_stream.read
      Nokogiri::XML(header_xml)
  end
end
```

This method scans the DOCX archive for header XML files (`word/header*.xml`), reads their content, and parses them using Nokogiri to return a list of Nokogiri XML documents representing each header.

### **Added footers method:**
Added `fetch_footers` method:

```ruby
def fetch_footers
    @zip.glob('word/footer*.xml').map do |entry|
      footer_xml = entry.get_input_stream.read
      Nokogiri::XML(footer_xml)
  end
end
```

Similar to the `fetch_headers` method, this method scans the DOCX archive for footer XML files (`word/footer*.xml`), reads their content, and parses them using Nokogiri to return a list of Nokogiri XML documents representing each footer.