### PR TITLE
Accepts files whose extension is not .docx or which does not have extension

### DIFF
--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -29,7 +29,6 @@ module Docx
 
       # if path-or_io is string && does not contain a null byte
       if (path_or_io.instance_of?(String) && !/\u0000/.match?(path_or_io))
-        raise Errno::EIO.new('Invalid file format') if !File.extname(path_or_io).eql?('.docx')
         @zip = Zip::File.open(path_or_io)
       else
         @zip = Zip::File.open_buffer(path_or_io)

--- a/spec/docx/document_spec.rb
+++ b/spec/docx/document_spec.rb
@@ -20,12 +20,6 @@ describe Docx::Document do
     end
 
     context 'When reading a un-supported file' do
-      it 'should throw file not supported error' do
-        expect do
-          Docx::Document.open(@fixtures_path + '/invalid_format.pdf')
-        end.to raise_error(Errno::EIO, 'Input/output error - Invalid file format')
-      end
-
       it 'should throw file not found error' do
         invalid_path = @fixtures_path + '/invalid_file_path.docx'
         expect do


### PR DESCRIPTION
As reported #162, the version of this gem only accepts files whose extension are .docx . 
This behavior should be  restored as claimed in the issue. 