### PR TITLE
Fixed #168. Rubyzip changed default behavior.

### DIFF
--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -5,6 +5,11 @@ require 'docx/helpers'
 require 'nokogiri'
 require 'zip'
 
+# Disable ZIP64 support to maintain compatibility with version 0.9.1 and
+# ensure compatibility with all readers. Rubyzip 3.x enables ZIP64 by default,
+# but many readers (including pandoc) don't support it for small files.
+Zip.write_zip64_support = false
+
 module Docx
   # The Document class wraps around a docx file and provides methods to
   # interface with it.

--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -5,9 +5,9 @@ require 'docx/helpers'
 require 'nokogiri'
 require 'zip'
 
-# Disable ZIP64 support to maintain compatibility with version 0.9.1 and
-# ensure compatibility with all readers. Rubyzip 3.x enables ZIP64 by default,
-# but many readers (including pandoc) don't support it for small files.
+# Disable ZIP64 support to maintain compatibility with the previous default behavior
+# (before rubyzip 3.x) and ensure compatibility with all readers. Rubyzip 3.x enables
+# ZIP64 by default, but many readers (including pandoc) don't support it for small files.
 Zip.write_zip64_support = false
 
 module Docx


### PR DESCRIPTION
The issue with file saving was that Rubyzip 3.x now saves ZIP64 by default. This is unexpected and unsupported by many tools, and best not to enable by default in docx.

I'd appreciate it if the maintainers merge this and release a new gem.