### PR TITLE
Fix compatibility with `--enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,6 +22,7 @@ jobs:
           - 3.2
           - 3.3
           - 3.4
+          - 4.0
           - head
 
     steps:
@@ -35,4 +36,6 @@ jobs:
     - name: Run tests
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        RUBYOPT: "--enable-frozen-string-literal --debug-frozen-string-literal"
       run: bundle exec rake spec
+

--- a/lib/docx/containers/paragraph.rb
+++ b/lib/docx/containers/paragraph.rb
@@ -44,7 +44,7 @@ module Docx
 
         # Return paragraph as a <p></p> HTML fragment with formatting based on properties.
         def to_html
-          html = ''
+          html = +''
           text_runs.each do |text_run|
             html << text_run.to_html
           end


### PR DESCRIPTION
This has been a supported option of Ruby since Ruby 2.3, and even without it, mutating a string literal emits a warning.