### PR TITLE
Scope ZIP64 disabling to save/stream (follow-up to #170)

### DIFF
--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -5,11 +5,6 @@ require 'docx/helpers'
 require 'nokogiri'
 require 'zip'
 
-# Disable ZIP64 support to maintain compatibility with the previous default behavior
-# (before rubyzip 3.x) and ensure compatibility with all readers. Rubyzip 3.x enables
-# ZIP64 by default, but many readers (including pandoc) don't support it for small files.
-Zip.write_zip64_support = false
-
 module Docx
   # The Document class wraps around a docx file and provides methods to
   # interface with it.
@@ -133,40 +128,44 @@ module Docx
     # call-seq:
     #   save(filepath) => void
     def save(path)
-      update
-      Zip::OutputStream.open(path) do |out|
-        zip.each do |entry|
-          next unless entry.file?
+      with_zip64_disabled do
+        update
+        Zip::OutputStream.open(path) do |out|
+          zip.each do |entry|
+            next unless entry.file?
 
-          out.put_next_entry(entry.name)
-          value = @replace[entry.name] || zip.read(entry.name)
+            out.put_next_entry(entry.name)
+            value = @replace[entry.name] || zip.read(entry.name)
 
-          out.write(value)
+            out.write(value)
+          end
+
         end
-
+        zip.close
       end
-      zip.close
     end
 
     # Output entire document as a StringIO object
     def stream
-      update
-      stream = Zip::OutputStream.write_buffer do |out|
-        zip.each do |entry|
-          next unless entry.file?
+      with_zip64_disabled do
+        update
+        stream = Zip::OutputStream.write_buffer do |out|
+          zip.each do |entry|
+            next unless entry.file?
 
-          out.put_next_entry(entry.name)
+            out.put_next_entry(entry.name)
 
-          if @replace[entry.name]
-            out.write(@replace[entry.name])
-          else
-            out.write(zip.read(entry.name))
+            if @replace[entry.name]
+              out.write(@replace[entry.name])
+            else
+              out.write(zip.read(entry.name))
+            end
           end
         end
-      end
 
-      stream.rewind
-      stream
+        stream.rewind
+        stream
+      end
     end
 
     alias text to_s
@@ -188,6 +187,18 @@ module Docx
     end
 
     private
+
+    # rubyzip 3.x enables ZIP64 by default, which breaks readers (e.g. pandoc)
+    # that don't support it for small files (issue #168). Disable ZIP64 only
+    # while writing, and restore the previous global value afterwards so we
+    # don't affect other rubyzip users in the consuming application.
+    def with_zip64_disabled
+      previous = Zip.write_zip64_support
+      Zip.write_zip64_support = false
+      yield
+    ensure
+      Zip.write_zip64_support = previous
+    end
 
     def load_styles
       @styles_xml = @zip.read('word/styles.xml')

--- a/spec/docx/document_spec.rb
+++ b/spec/docx/document_spec.rb
@@ -376,6 +376,31 @@ describe Docx::Document do
 
       after { File.delete(@new_doc_path) if File.exist?(@new_doc_path) }
     end
+
+    context 'ZIP64 global configuration' do
+      before { @doc = Docx::Document.open(@fixtures_path + '/basic.docx') }
+
+      around do |example|
+        previous = Zip.write_zip64_support
+        example.run
+        Zip.write_zip64_support = previous
+      end
+
+      it 'does not leak the disabled ZIP64 setting after saving' do
+        Zip.write_zip64_support = true
+        @new_doc_path = @fixtures_path + '/new_save.docx'
+        @doc.save(@new_doc_path)
+        expect(Zip.write_zip64_support).to eq(true)
+      end
+
+      it 'does not leak the disabled ZIP64 setting after streaming' do
+        Zip.write_zip64_support = true
+        @doc.stream
+        expect(Zip.write_zip64_support).to eq(true)
+      end
+
+      after { File.delete(@new_doc_path) if @new_doc_path && File.exist?(@new_doc_path) }
+    end
   end
 
   describe 'streaming' do


### PR DESCRIPTION
## Summary

Follow-up to #170, which fixed #168 by disabling rubyzip's ZIP64 support so that generated `.docx` files stay readable by tools that don't support ZIP64 (e.g. pandoc).

#170 set `Zip.write_zip64_support = false` at the top level of `lib/docx/document.rb`, i.e. as soon as the gem is required. As the Copilot review on #170 pointed out, this mutates **global** rubyzip state for the entire host application, which can break other code in the consuming app that legitimately relies on ZIP64.

This PR keeps the same fix for #168 but scopes the change to the write path only:

- Removes the top-level `Zip.write_zip64_support = false`.
- Wraps the bodies of `#save` and `#stream` in a private `with_zip64_disabled` helper that disables ZIP64 for the duration of the write and **restores the previous global value** in an `ensure` block — so other rubyzip users in the host app are unaffected.

## Tests

- `bundle exec rspec` — all green.
- Adds regression specs asserting `Zip.write_zip64_support` is **not** left mutated after `#save` / `#stream` (sets it to `true` beforehand and verifies it is still `true` afterwards).

## Notes

- Behaviour for end users is unchanged: produced documents still have ZIP64 disabled; only the side effect on global state is removed.

Refs #168, #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)