### PR TITLE
Add ability to read document footers (original work by @Jawad79Ahmad in #153)

### DIFF
--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -22,7 +22,7 @@ module Docx
   class Document
     include Docx::SimpleInspect
 
-    attr_reader :xml, :doc, :zip, :styles, :headers
+    attr_reader :xml, :doc, :zip, :styles, :headers, :footers
 
     def initialize(path_or_io, options = {})
       @replace = {}
@@ -41,6 +41,7 @@ module Docx
       @doc = Nokogiri::XML(@document_xml)
       load_styles
       load_headers
+      load_footers
       yield(self) if block_given?
     ensure
       @zip.close unless @zip.nil?
@@ -208,6 +209,15 @@ module Docx
         [simple_file_name, Nokogiri::XML(@zip.read(file))]
       end
       @headers = Hash[filename_and_contents_pairs]
+    end
+
+    def load_footers
+      footer_files = @zip.glob("word/footer*.xml").map{|h| h.name}
+      filename_and_contents_pairs = footer_files.map do |file|
+        simple_file_name = file.sub(/^word\//, "").sub(/\.xml$/, "")
+        [simple_file_name, Nokogiri::XML(@zip.read(file))]
+      end
+      @footers = Hash[filename_and_contents_pairs]
     end
 
     def load_styles

--- a/spec/docx/document_spec.rb
+++ b/spec/docx/document_spec.rb
@@ -72,6 +72,18 @@ describe Docx::Document do
     end
   end
 
+  describe 'read footers' do
+    before do
+      @doc = Docx::Document.open(@fixtures_path + '/multi_doc.docx')
+    end
+
+    it 'can extract footers' do
+      expect(@doc.footers).to_not be_nil
+      expect(@doc.footers.keys).to eq ["footer1"]
+      expect(@doc.footers["footer1"].text).to eq "Hello from the footer."
+    end
+  end
+
   describe 'read tables' do
     before do
       @doc = Docx::Document.open(@fixtures_path + '/tables.docx')


### PR DESCRIPTION
## Summary

Adds the ability to read document footers (`word/footer*.xml`) via a new `Docx::Document#footers` accessor. Footers are exposed as a `Hash` keyed by the footer file name (e.g. `"footer1"`), with each value being a parsed `Nokogiri::XML` document.

```ruby
doc = Docx::Document.open("with_footer.docx")
doc.footers["footer1"].text  # => "Hello from the footer."
```

This is the footer counterpart to the headers reading feature added in #173, and follows the exact same `load_*` convention (a private `load_footers` method called from `initialize`).

## Credit

The footer-reading capability is based on the original implementation by **@Jawad79Ahmad** in #153. They are credited as a co-author on the commit, and should be credited in the release notes when this ships.

## Scope

Reading only — consistent with the headers feature. Write-back (persisting edited footers on `save`/`stream`) is intentionally out of scope.

## Known limitations

- `footers` exposes mutable `Nokogiri` documents, but `update` does **not** write footers back. Editing a footer and saving will not persist the change (read-only).

## Tests

- Reuses the existing `spec/fixtures/multi_doc.docx` fixture, which already contains `word/footer1.xml` ("Hello from the footer."), so no new fixture is needed.
- Adds a `read footers` spec.
- Full suite green locally (`140 examples, 0 failures`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
