### PR TITLE
Persist header and footer edits on save (original work by @aashish in #42)

### DIFF
--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -245,6 +245,12 @@ module Docx
     def update
       replace_entry 'word/document.xml', doc.serialize(save_with: 0)
       replace_entry 'word/styles.xml', styles_configuration.serialize(save_with: 0)
+      headers.each do |name, content|
+        replace_entry "word/#{name}.xml", content.serialize(save_with: 0)
+      end
+      footers.each do |name, content|
+        replace_entry "word/#{name}.xml", content.serialize(save_with: 0)
+      end
     end
 
     # generate Elements::Containers::Paragraph from paragraph XML node

--- a/spec/docx/document_spec.rb
+++ b/spec/docx/document_spec.rb
@@ -84,6 +84,27 @@ describe Docx::Document do
     end
   end
 
+  describe 'updating headers and footers' do
+    before do
+      @doc = Docx::Document.open(@fixtures_path + '/multi_doc.docx')
+      @new_doc_path = @fixtures_path + '/multi_doc_saved.docx'
+    end
+
+    after do
+      File.delete(@new_doc_path) if File.exist?(@new_doc_path)
+    end
+
+    it 'persists changes to headers and footers after save' do
+      @doc.headers['header1'].at_xpath('//w:t').content = 'Edited header.'
+      @doc.footers['footer1'].at_xpath('//w:t').content = 'Edited footer.'
+      @doc.save(@new_doc_path)
+
+      reopened = Docx::Document.open(@new_doc_path)
+      expect(reopened.headers['header1'].text).to eq 'Edited header.'
+      expect(reopened.footers['footer1'].text).to eq 'Edited footer.'
+    end
+  end
+
   describe 'read tables' do
     before do
       @doc = Docx::Document.open(@fixtures_path + '/tables.docx')


### PR DESCRIPTION
## Summary

Makes header and footer edits persist on `save`/`stream`. Until now `Document#headers` and `#footers` (added in #173 / #174) were read-only — editing the returned `Nokogiri` documents had no effect because `update` only wrote back `document.xml` and `styles.xml`. This extends `update` to write each header/footer back into the archive.

```ruby
doc = Docx::Document.open("example.docx")
doc.headers["header1"].at_xpath("//w:t").content = "New header text"
doc.save("example.docx")   # change is now persisted
```

## Approach

Each header/footer is written back **keyed by its original file name** (the `headers`/`footers` Hash key, e.g. `"header1"`):

```ruby
headers.each { |name, content| replace_entry "word/#{name}.xml", content.serialize(save_with: 0) }
footers.each { |name, content| replace_entry "word/#{name}.xml", content.serialize(save_with: 0) }
```

Using the stored file name (rather than reconstructing `header#{index+1}.xml`) means documents with multiple or non-sequential header/footer files round-trip correctly without risk of overwriting the wrong entry.

## Credit

Based on the original read/write implementation by **@aashish** in #42. They are credited as a co-author on the commit and should be credited in the release notes when this ships.

## Tests

- Adds a round-trip spec: open `multi_doc.docx`, edit the header and footer text, save, reopen, and assert the changes persisted.
- Full suite green locally (`141 examples, 0 failures`).

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
