### PR TITLE
Accept Pathname when opening a document (#101)

### DIFF
--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -27,6 +27,9 @@ module Docx
     def initialize(path_or_io, options = {})
       @replace = {}
 
+      # accept path-like objects (e.g. Pathname, File) by using their path (#101)
+      path_or_io = path_or_io.to_path if path_or_io.respond_to?(:to_path)
+
       # if path-or_io is string && does not contain a null byte
       if (path_or_io.instance_of?(String) && !/\u0000/.match?(path_or_io))
         @zip = Zip::File.open(path_or_io)

--- a/spec/docx/document_spec.rb
+++ b/spec/docx/document_spec.rb
@@ -58,6 +58,18 @@ describe Docx::Document do
 
       it_behaves_like 'reading'
     end
+
+    # Regression test for #101: opening with a Pathname (or any path-like object)
+    # should work the same as a String path.
+    context 'using a Pathname' do
+      before do
+        require 'pathname'
+        path = Pathname.new(@fixtures_path + '/basic.docx')
+        @doc = Docx::Document.open(path)
+      end
+
+      it_behaves_like 'reading'
+    end
   end
 
   describe 'read headers' do


### PR DESCRIPTION
## Summary

Fixes #101. `Docx::Document.open` accepts a `Pathname` (and other path-like objects) again, restoring behavior that broke between 0.4.0 and 0.6.0.

## The bug

`initialize` only treated a `String` without a null byte as a file path; everything else was sent to `Zip::File.open_buffer`. A `Pathname` is not a `String`, so it fell through to `open_buffer` and raised:

```
Zip::File.open_buffer expects a String or IO-like argument
(responds to tell, seek, read, eof, close). Found: Pathname
```

This was an unintended API break (the major version did not change), as noted in #101.

## The fix

Path-like arguments — objects that respond to `#to_path` (e.g. `Pathname`, `File`) — are converted to their path string before the String/buffer branch, so they are opened by path:

```ruby
path_or_io = path_or_io.to_path if path_or_io.respond_to?(:to_path)
```

`StringIO` and raw binary strings do not respond to `#to_path`, so streaming/buffer input (#89) is unaffected.

## Tests

- Adds a `using a Pathname` context to the reading specs, reusing the shared `reading` examples.
- Confirmed it fails on `master` (raises on open) and passes with this change. Full suite green locally (`151 examples, 0 failures`).

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
