### PR TITLE
Pass document_properties to table cell paragraphs so to_html works with hyperlinks (#160)

### DIFF
--- a/lib/docx/containers/table.rb
+++ b/lib/docx/containers/table.rb
@@ -13,14 +13,16 @@ module Docx
           'tbl'
         end
 
-        def initialize(node)
+        def initialize(node, document_properties = {}, doc = nil)
           @node = node
           @properties_tag = 'tblGrid'
+          @document_properties = document_properties
+          @document = doc
         end
 
         # Array of row
         def rows
-          @node.xpath('w:tr').map {|r_node| Containers::TableRow.new(r_node) }
+          @node.xpath('w:tr').map {|r_node| Containers::TableRow.new(r_node, @document_properties, @document) }
         end
 
         def row_count
@@ -31,7 +33,7 @@ module Docx
         def columns
           columns_containers = []
           (0..(column_count-1)).each do |i|
-            columns_containers[i] = Containers::TableColumn.new @node.xpath("w:tr//w:tc[#{i+1}]")
+            columns_containers[i] = Containers::TableColumn.new(@node.xpath("w:tr//w:tc[#{i+1}]"), @document_properties, @document)
           end
           columns_containers
         end

--- a/lib/docx/containers/table_cell.rb
+++ b/lib/docx/containers/table_cell.rb
@@ -12,9 +12,11 @@ module Docx
           'tc'
         end
 
-        def initialize(node)
+        def initialize(node, document_properties = {}, doc = nil)
           @node = node
           @properties_tag = 'tcPr'
+          @document_properties = document_properties
+          @document = doc
         end
 
         # Return text of paragraph's cell
@@ -24,7 +26,7 @@ module Docx
 
         # Array of paragraphs contained within cell
         def paragraphs
-          @node.xpath('w:p').map {|p_node| Containers::Paragraph.new(p_node) }
+          @node.xpath('w:p').map {|p_node| Containers::Paragraph.new(p_node, @document_properties, @document) }
         end
 
         # Iterate over each text run within a paragraph's cell

--- a/lib/docx/containers/table_column.rb
+++ b/lib/docx/containers/table_column.rb
@@ -12,10 +12,12 @@ module Docx
           'w:gridCol'
         end
 
-        def initialize(cell_nodes)
+        def initialize(cell_nodes, document_properties = {}, doc = nil)
           @node = ''
           @properties_tag = ''
-          @cells = cell_nodes.map { |c_node| Containers::TableCell.new(c_node) }
+          @document_properties = document_properties
+          @document = doc
+          @cells = cell_nodes.map { |c_node| Containers::TableCell.new(c_node, @document_properties, @document) }
         end
 
         # Array of cells contained within row

--- a/lib/docx/containers/table_row.rb
+++ b/lib/docx/containers/table_row.rb
@@ -12,14 +12,16 @@ module Docx
           'tr'
         end
 
-        def initialize(node)
+        def initialize(node, document_properties = {}, doc = nil)
           @node = node
           @properties_tag = ''
+          @document_properties = document_properties
+          @document = doc
         end
 
         # Array of cells contained within row
         def cells
-          @node.xpath('w:tc').map {|c_node| Containers::TableCell.new(c_node) }
+          @node.xpath('w:tc').map {|c_node| Containers::TableCell.new(c_node, @document_properties, @document) }
         end
         
       end

--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -275,7 +275,7 @@ module Docx
     end
 
     def parse_table_from(t_node)
-      Elements::Containers::Table.new(t_node)
+      Elements::Containers::Table.new(t_node, document_properties, self)
     end
   end
 end

--- a/spec/docx/document_spec.rb
+++ b/spec/docx/document_spec.rb
@@ -202,6 +202,15 @@ describe Docx::Document do
       expect(@doc.tables[0].columns[1].cells[1].text).to match(/^Directive/)
     end
 
+    # Regression test for #160: rendering html for a cell that contains a
+    # hyperlink must not raise (the cell's paragraphs need document_properties).
+    it 'renders html for cells containing hyperlinks' do
+      cell = @doc.tables[0].rows[1].cells[1]
+      html = nil
+      expect { html = cell.paragraphs.map(&:to_html).join }.to_not raise_error
+      expect(html).to include('<a href="http://google.com/"')
+    end
+
     describe '#paragraphs' do
       it 'should not grabs paragraphs in the tables' do
         expect(@doc.paragraphs.map(&:text)).to_not include("Second table")


### PR DESCRIPTION
## Summary

Fixes #160. Calling `to_html` on a paragraph inside a table cell that contains a hyperlink no longer raises.

## The bug

`TableCell#paragraphs` built `Paragraph` objects without `document_properties`, so each paragraph's `@document_properties` defaulted to `{}`. When such a paragraph contained a hyperlink, `TextRun#href` evaluated `@document_properties[:hyperlinks][hyperlink_id]` — and `[:hyperlinks]` was `nil`:

```
doc.tables[0].rows[0].cells[0].paragraphs.map(&:to_html)
# => NoMethodError: undefined method '[]' for nil
```

The root cause was identified by the reporter (@perryn): table cells had no access to `document_properties`.

## The fix

Thread `document_properties` (and the owning document) down through the table containers, mirroring how body paragraphs are built via `parse_paragraph_from`:

`Document#parse_table_from` → `Table` → `TableRow` / `TableColumn` → `TableCell` → `Paragraph`

All new constructor arguments are **optional** (`document_properties = {}`, `doc = nil`), so existing direct instantiations keep working. As a bonus, paragraph `style` now resolves inside table cells too (it needs the document reference).

## Tests

- New regression spec renders html for `tables.docx`'s cell `[0].rows[1].cells[1]`, which links to `http://google.com/`, asserting it does not raise and the output contains `<a href="http://google.com/"`.
- Confirmed it fails on `master` (`NoMethodError`) and passes with this change. Full suite green locally (`152 examples, 0 failures`).

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
