### PR TITLE
Fix placeholder consolidation reintroducing stray braces on shared boundary runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/*
 doc/
 vendor/
 coverage/
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.4
+
+### Bug fixes
+
+- Fix placeholder consolidation reintroducing a stray `}}` when two `{{...}}` placeholders share a boundary run (e.g. Word emits `}} in Grade {{` around proofing marks). Consolidation is now a single position-ordered pass that keeps each placeholder atomic and never alters the paragraph's visible text.
+
 ## v0.7.0
 
 ### Enhancements

--- a/lib/docx/containers/paragraph.rb
+++ b/lib/docx/containers/paragraph.rb
@@ -28,6 +28,7 @@ module Docx
           validate_placeholder_content
         end
 
+        # This method detects and replaces the corrupted nodes if any exists.
         def validate_placeholder_content
           placeholder_position_hash = detect_placeholder_positions
           content_size = [0]

--- a/lib/docx/containers/paragraph.rb
+++ b/lib/docx/containers/paragraph.rb
@@ -8,6 +8,8 @@ module Docx
         include Container
         include Elements::Element
 
+        PLACEHOLDER_REGEX = /\{\{(.*?)\}\}/ # In order to combine text runs with {{}} pattern
+
         def self.tag
           'p'
         end
@@ -15,12 +17,80 @@ module Docx
 
         # Child elements: pPr, r, fldSimple, hlink, subDoc
         # http://msdn.microsoft.com/en-us/library/office/ee364458(v=office.11).aspx
+        #
+        # See: https://github.com/ruby-docx/docx/issues/147 for placeholder patching
         def initialize(node, document_properties = {}, doc = nil)
           @node = node
           @properties_tag = 'pPr'
           @document_properties = document_properties
           @font_size = @document_properties[:font_size]
           @document = doc
+          validate_placeholder_content
+        end
+
+        def validate_placeholder_content
+          placeholder_position_hash = detect_placeholder_positions
+          content_size = [0]
+          text_runs.each_with_index do |text_node, index|
+            content_size[index + 1] = text_node.text.length + (index.zero? ? 0 : content_size[index])
+          end
+          content_size.pop
+          placeholder_position_hash.each do |placeholder, placeholder_positions|
+            placeholder_positions.each do |p_start_index|
+              p_end_index = (p_start_index + placeholder.length - 1)
+              tn_start_index = content_size.index(content_size.select { |size| size <= p_start_index }.max)
+              tn_end_index = content_size.index(content_size.select { |size| size <= p_end_index }.max)
+              next if tn_start_index == tn_end_index
+              replace_incorrect_placeholder_content(placeholder, tn_start_index, tn_end_index, content_size[tn_start_index] - p_start_index, p_end_index - content_size[tn_end_index])
+            end
+          end
+        end
+
+        # This method detect the placeholder's starting index and return the starting index in array.
+        # Ex: Assumptions : text = 'This is Placeholder Text with {{Placeholder}} {{Text}} {{Placeholder}}'
+        #     It will detect the placeholder's starting index from the given text.
+        #     Here, starting index of '{{Placeholder}}' => [30, 55], '{{Text}}' => [46]
+        # @return [Hash]
+        # Ex: {'{{Placeholder}}' => [30, 55], '{{Text}}' => [46]}
+        def detect_placeholder_positions
+          text.scan(PLACEHOLDER_REGEX).flatten.uniq.each_with_object({}) do |placeholder, placeholder_hash|
+            next if placeholder.include?("{") || placeholder.include?("}")
+            placeholder_text = "{{#{placeholder}}}"
+            current_index = text.index(placeholder_text)
+            arr_of_index = [current_index]
+            until current_index.nil?
+              current_index = text.index(placeholder_text, current_index + 1)
+              arr_of_index << current_index unless current_index.nil?
+            end
+            placeholder_hash[placeholder_text] = arr_of_index
+          end
+        end
+
+        # @param [String] :placeholder
+        # @param [Integer] :start_index, end_index, p_start_index, p_end_index
+        # This Method replaces below :
+        #   1. Corrupted text nodes content with empty string
+        #   2. Proper Placeholder content within the same text node
+        # Ex: Assume we have a array of text nodes content as text_runs = ['This is ', 'Placeh', 'older Text', 'with ', '{{', 'Place', 'holder}}' , '{{Text}}', '{{Placeholder}}']
+        #   Here if you see, the '{{placeholder}}' is not available in the same text node. We need to merge the content of indexes - text_runs[5], text_runs[6], text_runs[7].
+        #   So We will replace the content as below:
+        #     1. text_runs[5] = '{{Placeholder}}'
+        #     2. text_runs[6] = ''
+        #     3. text_runs[7] = ''
+        def replace_incorrect_placeholder_content(placeholder, start_index, end_index, p_start_index, p_end_index)
+          (start_index..end_index).each do |index|
+            if index == start_index
+              current_text = text_runs[index].text.to_s
+              current_text[p_start_index..-1] = placeholder
+              text_runs[index].text = current_text
+            elsif index == end_index
+              current_text = text_runs[index].text.to_s
+              current_text[0..p_end_index] = ""
+              text_runs[index].text = current_text
+            else
+              text_runs[index].text = ""
+            end
+          end
         end
 
         # Set text of paragraph

--- a/lib/docx/containers/paragraph.rb
+++ b/lib/docx/containers/paragraph.rb
@@ -31,40 +31,49 @@ module Docx
         def validate_placeholder_content
           # First, build a map of all text run contents and their positions
           content_map = build_content_map
-          full_text = text_runs.map(&:text).join('')
+          full_text = content_map.map { |m| m[:text] }.join('')
 
           # Use global regex to find all placeholders with their positions
           placeholders = full_text.to_enum(:scan, PLACEHOLDER_REGEX).map do
             [Regexp.last_match.begin(0), Regexp.last_match.end(0)]
           end
+          return if placeholders.empty?
 
-          placeholders.each do |start_pos, end_pos|
-            # Find the indexes of the text runs that includes the start and end of the placeholder
-            start_text_run_index = content_map.index { |m| m[:start] <= start_pos && m[:end] >= start_pos }
-            end_text_run_index = content_map.index { |m| m[:start] <= end_pos - 1 && m[:end] >= end_pos - 1 }
-
-            next if start_text_run_index.nil? || end_text_run_index.nil?
-            next if start_text_run_index == end_text_run_index # Skip if entire placeholder is already in single run
-
-            placeholder_content = full_text[start_pos...end_pos]
-
-            (start_text_run_index..end_text_run_index).each do |i|
-              if i == start_text_run_index
-                # Merge the entire placeholder into the first run
-                current_text = content_map[i][:text].dup
-                current_text[start_pos - content_map[i][:start]..-1] = placeholder_content
-                content_map[i][:run].text = current_text
-              elsif i == end_text_run_index
-                # Last run should preserve any content after the placeholder
-                current_text = content_map[i][:text].dup
-                remaining_text = current_text[(end_pos) - content_map[i][:start]..-1]
-                content_map[i][:run].text = remaining_text
-              else
-                # Clear intermediate runs
-                content_map[i][:run].text = ''
-              end
+          # Reassign text to runs so each placeholder lands wholly in the run
+          # that holds its opening "{{", while every other character stays in its
+          # original run. We build the result in a single position-ordered pass
+          # rather than editing runs in place from the static map: when one
+          # token's closing "}}" shares a run with the next token's "{{" (Word
+          # emits such runs around proofing marks, e.g. "}} at CTC {{"), in-place
+          # editing rewrote that shared run from stale text and resurrected the
+          # "}}" a previous placeholder had already trimmed. A single pass keeps
+          # every placeholder atomic and never reintroduces a trimmed brace.
+          new_texts = Array.new(content_map.length) { +'' }
+          pos = 0
+          next_placeholder = 0
+          while pos < full_text.length
+            if next_placeholder < placeholders.length && placeholders[next_placeholder][0] == pos
+              start_pos, end_pos = placeholders[next_placeholder]
+              owner = run_index_at(content_map, start_pos)
+              new_texts[owner] << full_text[start_pos...end_pos] if owner
+              pos = end_pos
+              next_placeholder += 1
+            else
+              owner = run_index_at(content_map, pos)
+              new_texts[owner] << full_text[pos] if owner
+              pos += 1
             end
           end
+
+          content_map.each_with_index do |entry, i|
+            entry[:run].text = new_texts[i] unless new_texts[i] == entry[:text]
+          end
+        end
+
+        # Index of the run whose original span covers the given character
+        # position. Empty runs occupy no positions and are never returned.
+        def run_index_at(content_map, position)
+          content_map.index { |m| m[:start] <= position && m[:end] >= position }
         end
 
         def build_content_map

--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -22,7 +22,7 @@ module Docx
   class Document
     include Docx::SimpleInspect
 
-    attr_reader :xml, :doc, :zip, :styles
+    attr_reader :xml, :doc, :zip, :styles, :headers, :footers
 
     def initialize(path_or_io, options = {})
       @replace = {}
@@ -40,6 +40,8 @@ module Docx
 
       @document_xml = document.get_input_stream.read
       @doc = Nokogiri::XML(@document_xml)
+      @headers = fetch_headers
+      @footers = fetch_footers
       load_styles
       yield(self) if block_given?
     ensure
@@ -73,6 +75,20 @@ module Docx
       bkmrks_ary.reject! { |b| b.name == '_GoBack' }
       bkmrks_ary.each { |b| bkmrks_hsh[b.name] = b }
       bkmrks_hsh
+    end
+
+    def fetch_headers
+      @zip.glob('word/header*.xml').map do |entry|
+        header_xml = entry.get_input_stream.read
+        Nokogiri::XML(header_xml)
+      end
+    end
+
+    def fetch_footers
+      @zip.glob('word/footer*.xml').map do |entry|
+        footer_xml = entry.get_input_stream.read
+        Nokogiri::XML(footer_xml)
+      end
     end
 
     def to_xml
@@ -210,6 +226,12 @@ module Docx
     def update
       replace_entry 'word/document.xml', doc.serialize(save_with: 0)
       replace_entry 'word/styles.xml', styles_configuration.serialize(save_with: 0)
+      headers.each_with_index do |header, index|
+        replace_entry "word/header#{index + 1}.xml", header.serialize(:save_with => 0) if header
+      end
+      footers.each_with_index do |footer, index|
+        replace_entry "word/footer#{index + 1}.xml", footer.serialize(:save_with => 0) if footer
+      end
     end
 
     # generate Elements::Containers::Paragraph from paragraph XML node

--- a/spec/docx/paragraph_placeholder_spec.rb
+++ b/spec/docx/paragraph_placeholder_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'docx/document'
+
+describe 'Paragraph placeholder consolidation' do
+  let(:described_class) { Docx::Elements::Containers::Paragraph }
+
+  # Builds a bare <w:p> node so placeholder consolidation can be exercised
+  # without a full .docx fixture.
+  def paragraph_from(inner_runs)
+    xml = <<~XML
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        #{inner_runs}
+      </w:p>
+    XML
+    node = Nokogiri::XML(xml).root
+    described_class.new(node)
+  end
+
+  describe '#validate_placeholder_content' do
+    # Reproduces the real customer template: Word splits each {{token}} across
+    # runs (proofing marks) and fuses one token's closing "}}" into the same run
+    # as the next token's opening "{{" (e.g. a run reading "}} at CTC {{"). Two
+    # placeholders then share that boundary run.
+    let(:shared_boundary_runs) do
+      <<~XML
+        <w:r><w:t xml:space="preserve">Your title is {{</w:t></w:r>
+        <w:proofErr w:type="spellStart"/>
+        <w:r><w:t>offer.job_title</w:t></w:r>
+        <w:proofErr w:type="spellEnd"/>
+        <w:r><w:t xml:space="preserve">}} at CTC {{</w:t></w:r>
+        <w:proofErr w:type="spellStart"/>
+        <w:r><w:t>offer.salary_amount</w:t></w:r>
+        <w:proofErr w:type="spellEnd"/>
+        <w:r><w:t>}}.</w:t></w:r>
+      XML
+    end
+
+    it 'consolidates without altering the visible text' do
+      paragraph = paragraph_from(shared_boundary_runs)
+
+      expect(paragraph.text).to eq('Your title is {{offer.job_title}} at CTC {{offer.salary_amount}}.')
+    end
+
+    it 'keeps each placeholder within a single run so substitution leaves no orphan brace' do
+      paragraph = paragraph_from(shared_boundary_runs)
+
+      paragraph.each_text_run do |run|
+        run.substitute('{{offer.job_title}}', 'Senior Account Executive')
+        run.substitute('{{offer.salary_amount}}', '44,00,000')
+      end
+
+      expect(paragraph.text).to eq('Your title is Senior Account Executive at CTC 44,00,000.')
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When a Word document splits placeholders across runs (proofing marks — `<w:proofErr>`) and fuses one token's closing `}}` into the same run as the *next* token's opening `{{` — e.g. a run whose text is literally `}} in Grade {{` — `validate_placeholder_content` corrupts the paragraph.

It builds the run/position map **once**, then edits runs in place per placeholder. When two placeholders share that boundary run, processing the second placeholder rewrites the shared run from the **stale** cached text, **resurrecting** the `}}` the first placeholder's merge had already trimmed. The paragraph's visible text changes (`{{a}}` becomes `{{a}}}}`), and after substitution the value renders with a trailing `}}` (`Senior Account Executive}}`).

Downstream (Kula ENG-3355): offer-letter merge fields rendered with a stray `}}` after the value.

## Fix

Replace the in-place, static-map editing with a **single position-ordered reconstruction pass**: walk the joined text once, assign each placeholder wholly to the run holding its opening `{{`, and assign every other character to its original run. This keeps each placeholder atomic even when tokens share a boundary run, and — unlike the old code — never changes the paragraph's overall visible text.

## Tests

`spec/docx/paragraph_placeholder_spec.rb` builds the exact shared-boundary structure and asserts:
1. consolidation does not alter the visible text (fails on old code: `{{offer.job_title}}}}`);
2. after substitution there is no orphan brace (fails on old code: `Senior Account Executive}}`).

- New spec: 2 examples. Full suite: **138 examples, 0 failures** (was 136 + 2 new; no regressions).
- Verified against the real customer template: `Executive}}`, `44,00,000}}`, `L5}}` no longer appear; genuine unresolved placeholders (`{{docusign.*}}` etc.) are left intact.

## Note

Please cut a `v1.0.4` tag on merge — Kula core pins this fork by tag and will bump to it.