### PR TITLE
Fix header/footer reindex corruption on save/stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/*
 doc/
 vendor/
 coverage/
+.idea

--- a/lib/docx/containers/paragraph.rb
+++ b/lib/docx/containers/paragraph.rb
@@ -28,6 +28,7 @@ module Docx
           validate_placeholder_content
         end
 
+        # This method detects and replaces the corrupted nodes if any exists.
         def validate_placeholder_content
           placeholder_position_hash = detect_placeholder_positions
           content_size = [0]

--- a/lib/docx/containers/paragraph.rb
+++ b/lib/docx/containers/paragraph.rb
@@ -8,6 +8,8 @@ module Docx
         include Container
         include Elements::Element
 
+        PLACEHOLDER_REGEX = /\{\{(.*?)\}\}/ # In order to combine text runs with {{}} pattern
+
         def self.tag
           'p'
         end
@@ -15,12 +17,80 @@ module Docx
 
         # Child elements: pPr, r, fldSimple, hlink, subDoc
         # http://msdn.microsoft.com/en-us/library/office/ee364458(v=office.11).aspx
+        #
+        # See: https://github.com/ruby-docx/docx/issues/147 for placeholder patching
         def initialize(node, document_properties = {}, doc = nil)
           @node = node
           @properties_tag = 'pPr'
           @document_properties = document_properties
           @font_size = @document_properties[:font_size]
           @document = doc
+          validate_placeholder_content
+        end
+
+        def validate_placeholder_content
+          placeholder_position_hash = detect_placeholder_positions
+          content_size = [0]
+          text_runs.each_with_index do |text_node, index|
+            content_size[index + 1] = text_node.text.length + (index.zero? ? 0 : content_size[index])
+          end
+          content_size.pop
+          placeholder_position_hash.each do |placeholder, placeholder_positions|
+            placeholder_positions.each do |p_start_index|
+              p_end_index = (p_start_index + placeholder.length - 1)
+              tn_start_index = content_size.index(content_size.select { |size| size <= p_start_index }.max)
+              tn_end_index = content_size.index(content_size.select { |size| size <= p_end_index }.max)
+              next if tn_start_index == tn_end_index
+              replace_incorrect_placeholder_content(placeholder, tn_start_index, tn_end_index, content_size[tn_start_index] - p_start_index, p_end_index - content_size[tn_end_index])
+            end
+          end
+        end
+
+        # This method detect the placeholder's starting index and return the starting index in array.
+        # Ex: Assumptions : text = 'This is Placeholder Text with {{Placeholder}} {{Text}} {{Placeholder}}'
+        #     It will detect the placeholder's starting index from the given text.
+        #     Here, starting index of '{{Placeholder}}' => [30, 55], '{{Text}}' => [46]
+        # @return [Hash]
+        # Ex: {'{{Placeholder}}' => [30, 55], '{{Text}}' => [46]}
+        def detect_placeholder_positions
+          text.scan(PLACEHOLDER_REGEX).flatten.uniq.each_with_object({}) do |placeholder, placeholder_hash|
+            next if placeholder.include?("{") || placeholder.include?("}")
+            placeholder_text = "{{#{placeholder}}}"
+            current_index = text.index(placeholder_text)
+            arr_of_index = [current_index]
+            until current_index.nil?
+              current_index = text.index(placeholder_text, current_index + 1)
+              arr_of_index << current_index unless current_index.nil?
+            end
+            placeholder_hash[placeholder_text] = arr_of_index
+          end
+        end
+
+        # @param [String] :placeholder
+        # @param [Integer] :start_index, end_index, p_start_index, p_end_index
+        # This Method replaces below :
+        #   1. Corrupted text nodes content with empty string
+        #   2. Proper Placeholder content within the same text node
+        # Ex: Assume we have a array of text nodes content as text_runs = ['This is ', 'Placeh', 'older Text', 'with ', '{{', 'Place', 'holder}}' , '{{Text}}', '{{Placeholder}}']
+        #   Here if you see, the '{{placeholder}}' is not available in the same text node. We need to merge the content of indexes - text_runs[5], text_runs[6], text_runs[7].
+        #   So We will replace the content as below:
+        #     1. text_runs[5] = '{{Placeholder}}'
+        #     2. text_runs[6] = ''
+        #     3. text_runs[7] = ''
+        def replace_incorrect_placeholder_content(placeholder, start_index, end_index, p_start_index, p_end_index)
+          (start_index..end_index).each do |index|
+            if index == start_index
+              current_text = text_runs[index].text.to_s
+              current_text[p_start_index..-1] = placeholder
+              text_runs[index].text = current_text
+            elsif index == end_index
+              current_text = text_runs[index].text.to_s
+              current_text[0..p_end_index] = ""
+              text_runs[index].text = current_text
+            else
+              text_runs[index].text = ""
+            end
+          end
         end
 
         # Set text of paragraph

--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -22,7 +22,7 @@ module Docx
   class Document
     include Docx::SimpleInspect
 
-    attr_reader :xml, :doc, :zip, :styles
+    attr_reader :xml, :doc, :zip, :styles, :headers, :footers
 
     def initialize(path_or_io, options = {})
       @replace = {}
@@ -40,6 +40,8 @@ module Docx
 
       @document_xml = document.get_input_stream.read
       @doc = Nokogiri::XML(@document_xml)
+      @headers = fetch_headers
+      @footers = fetch_footers
       load_styles
       yield(self) if block_given?
     ensure
@@ -73,6 +75,20 @@ module Docx
       bkmrks_ary.reject! { |b| b.name == '_GoBack' }
       bkmrks_ary.each { |b| bkmrks_hsh[b.name] = b }
       bkmrks_hsh
+    end
+
+    def fetch_headers
+      @zip.glob('word/header*.xml').map do |entry|
+        header_xml = entry.get_input_stream.read
+        Nokogiri::XML(header_xml)
+      end
+    end
+
+    def fetch_footers
+      @zip.glob('word/footer*.xml').map do |entry|
+        footer_xml = entry.get_input_stream.read
+        Nokogiri::XML(footer_xml)
+      end
     end
 
     def to_xml
@@ -210,6 +226,12 @@ module Docx
     def update
       replace_entry 'word/document.xml', doc.serialize(save_with: 0)
       replace_entry 'word/styles.xml', styles_configuration.serialize(save_with: 0)
+      headers.each_with_index do |header, index|
+        replace_entry "word/header#{index + 1}.xml", header.serialize(:save_with => 0) if header
+      end
+      footers.each_with_index do |footer, index|
+        replace_entry "word/footer#{index + 1}.xml", footer.serialize(:save_with => 0) if footer
+      end
     end
 
     # generate Elements::Containers::Paragraph from paragraph XML node

--- a/lib/docx/document.rb
+++ b/lib/docx/document.rb
@@ -78,16 +78,19 @@ module Docx
     end
 
     def fetch_headers
-      @zip.glob('word/header*.xml').map do |entry|
-        header_xml = entry.get_input_stream.read
-        Nokogiri::XML(header_xml)
+      # Remember each part's real filename. glob returns entries in the zip's
+      # central-directory order, which is not always header1,2,3 — so #update
+      # must write each part back to its own name, not a positional index.
+      @header_names = @zip.glob('word/header*.xml').map(&:name)
+      @header_names.map do |name|
+        Nokogiri::XML(@zip.read(name))
       end
     end
 
     def fetch_footers
-      @zip.glob('word/footer*.xml').map do |entry|
-        footer_xml = entry.get_input_stream.read
-        Nokogiri::XML(footer_xml)
+      @footer_names = @zip.glob('word/footer*.xml').map(&:name)
+      @footer_names.map do |name|
+        Nokogiri::XML(@zip.read(name))
       end
     end
 
@@ -227,10 +230,10 @@ module Docx
       replace_entry 'word/document.xml', doc.serialize(save_with: 0)
       replace_entry 'word/styles.xml', styles_configuration.serialize(save_with: 0)
       headers.each_with_index do |header, index|
-        replace_entry "word/header#{index + 1}.xml", header.serialize(:save_with => 0) if header
+        replace_entry @header_names[index], header.serialize(:save_with => 0) if header
       end
       footers.each_with_index do |footer, index|
-        replace_entry "word/footer#{index + 1}.xml", footer.serialize(:save_with => 0) if footer
+        replace_entry @footer_names[index], footer.serialize(:save_with => 0) if footer
       end
     end
 

--- a/spec/docx/document_spec.rb
+++ b/spec/docx/document_spec.rb
@@ -387,6 +387,65 @@ describe Docx::Document do
 
       it_behaves_like 'reading'
     end
+
+    # Regression: #update wrote headers/footers back by positional index
+    # ("word/header#{i+1}.xml"), but glob returns entries in the zip's
+    # central-directory order, which is not always sorted. When header2.xml
+    # was stored before header1.xml, header2's content got written into
+    # header1.xml and header2.xml (the default header ref) was overwritten
+    # with a different part — blanking the header in the rendered output.
+    context 'when header/footer parts are stored out of numeric order' do
+      def build_docx(entries)
+        require 'zip'
+        buffer = Zip::OutputStream.write_buffer do |out|
+          entries.each do |name, content|
+            out.put_next_entry(name)
+            out.write(content)
+          end
+        end
+        buffer.rewind
+        buffer
+      end
+
+      let(:header2_body) { '<w:p><w:r><w:t>HEADER TWO CONTENT</w:t></w:r></w:p>' }
+      let(:header_xml) do
+        lambda do |body|
+          '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' \
+            '<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' \
+            "#{body}</w:hdr>"
+        end
+      end
+
+      let(:stream) do
+        # header2.xml is intentionally written to the zip BEFORE header1.xml.
+        entries = [
+          ['word/header2.xml', header_xml.call(header2_body)],
+          ['word/header1.xml', header_xml.call('<w:p/>')],
+          ['word/document.xml',
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' \
+            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' \
+            '<w:body><w:p><w:r><w:t>Body</w:t></w:r></w:p></w:body></w:document>'],
+          ['word/styles.xml',
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' \
+            '<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' \
+            '<w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>' \
+            '</w:styles>'],
+          ['word/_rels/document.xml.rels',
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' \
+            '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>']
+        ]
+        Docx::Document.open(build_docx(entries)).stream
+      end
+
+      it 'keeps each header part under its own filename after streaming' do
+        require 'zip'
+        header2 = nil
+        Zip::File.open_buffer(stream) do |zip|
+          header2 = zip.read('word/header2.xml')
+        end
+        expect(header2).to include('HEADER TWO CONTENT')
+      end
+    end
   end
 
   describe 'outputting html' do


### PR DESCRIPTION
See commit. #update wrote header/footer parts back by positional index while glob returns zip central-directory order (not always sorted), so out-of-order parts were written to the wrong file and the default header ref got blanked. Fix: capture each part's real filename at fetch and write back to it. No-op for sorted docs; only fixes the corrupt case. Regression test added (red without fix); full suite 137 green.